### PR TITLE
chore: migrate Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
-  "extends": ["config:base"],
-  "regexManagers": [
+  "extends": ["config:recommended"],
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["^snap/snapcraft\\.yaml$"],
       "matchStrings": [
         "source-tag:\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
@@ -13,13 +14,13 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "enabled": false
     },
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "shellhub-io/shellhub"
       ],
       "enabled": true


### PR DESCRIPTION
## Summary
- Migrates Renovate from deprecated `config:base` to `config:recommended`
- Replaces the deprecated `regexManagers` block with `customManagers` + `customType: "regex"`
- Renames the package rule matchers from `matchPackagePatterns` to `matchPackageNames` while keeping the same allow-list behavior for `shellhub-io/shellhub`

## Why
The Dependency Dashboard in #8 currently reports **Config Migration Needed**. This PR applies the narrow public Renovate config-shape migration while preserving the existing snapcraft tag matcher and package rules.

## Test plan
- `python3 -m json.tool .github/renovate.json`

Public-data-only cleanup; no credentials, registry, publishing, or account settings changed.
