### PR TITLE
feat: expose shellhub-agent command via snap alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ ShellHub is available in the [Snap Store](https://snapcraft.io/shellhub). To ins
 $ sudo snap install --classic shellhub
 ```
 
+## Usage
+
+After installation, interact with the ShellHub agent using the `shellhub-agent` command:
+
+```
+$ shellhub-agent info
+```
+
 > [!NOTE]
 > By default, the ShellHub is configured to use the [ShellHub Cloud](https://cloud.shellhub.io),
 > making it easy to get started without needing to set up a self-hosted instance.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,10 @@ apps:
     daemon: simple
     restart-condition: always
     stop-mode: sigterm
+  agent:
+    command: bin/shellhub.wrapper
+    aliases:
+      - shellhub-agent
 
 parts:
   shellhub:


### PR DESCRIPTION
## What

The snap package only exposed the `shellhub` app (a background daemon), leaving no user-facing CLI command after installation. Every other install method (Docker, Podman, standalone) exposes `shellhub-agent` on the host, making snap inconsistent.

This was identified as a follow-up to shellhub-io/shellhub#6462, which introduced `shellhub-agent` for Docker/Podman installs, and shellhub-io/shellhub#6504, which fixed a regression in that wrapper.

## Why

Operators should get a consistent `shellhub-agent` command regardless of how they installed the agent. Snap is the only install method that doesn't provide it.

## Changes

- `snap/snapcraft.yaml`: add `agent` app pointing to the same wrapper binary as the daemon, with `shellhub-agent` declared as an automatic alias pending Snap Store approval
- `README.md`: add Usage section documenting `shellhub-agent` as the user-facing command

## Testing

Built and tested locally in an Ubuntu 24.04 VM:

- Confirmed `shellhub-agent` is absent before the change (`which shellhub-agent` returns nothing)
- Built the modified snap with `snapcraft --destructive-mode`
- Installed with `sudo snap install --dangerous --classic shellhub_*.snap`
- Confirmed `shellhub.agent` is available after install
- Confirmed the alias works after manual activation via `sudo snap alias shellhub.agent shellhub-agent` (automatic in a published snap once Store-approved)

Closes #14
