### PR TITLE
feat: support install keys and pairing enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,72 @@ $ sudo snap install --classic shellhub
 
 ## Usage
 
-After installation, interact with the ShellHub agent using the `shellhub-agent` command:
+After installation the `shellhub` service starts and the `shellhub-agent`
+command is available:
 
 ```
 $ shellhub-agent info
 ```
 
+By default the agent connects to [ShellHub Cloud](https://cloud.shellhub.io).
+For a self-hosted server, point it at your instance before enrolling:
+
+```
+$ sudo snap set shellhub server-address=https://your.server
+```
+
+Changes to `server-address`, `tenant-id`, `install-key` and `private-key`
+restart the service automatically.
+
 > [!NOTE]
-> By default, the ShellHub is configured to use the [ShellHub Cloud](https://cloud.shellhub.io),
-> making it easy to get started without needing to set up a self-hosted instance.
-> You just need to set the `tenant-id` to connect your device to your ShellHub Cloud namespace.
+> Install keys and pairing need agent v0.27.0 or later. Earlier versions only
+> enroll with `tenant-id`.
+
+### Install key (fleets)
+
+Create an install key in the console (Settings > Install Keys) and set it
+together with the tenant ID of the namespace. The server accepts the device
+according to the key's mode and applies the key's tags:
+
+```
+$ sudo snap set shellhub tenant-id=<tenant-id> install-key=<key>
+```
+
+An install key without a `tenant-id` is ignored and the agent falls back to
+pairing.
+
+### Pairing (single device)
+
+With no `tenant-id` and no `install-key` the service boots into pairing mode:
+it logs an accept URL and waits for a user to accept the device into a
+namespace. Run the login command to print the URL (and open it in a browser
+when one is available):
+
+```
+$ sudo shellhub-agent login
+```
+
+The URL is also in the service log:
+
+```
+$ sudo snap logs shellhub
+```
+
+The namespace learned from the pairing is stored next to the private key
+(`/etc/shellhub.key.tenant`) and reused on later starts. A pairing code expires
+after a while; once it does the service stops polling the server and only
+waits for `shellhub-agent login` to complete, so run it again to get a new
+code.
+
+### Tenant ID only (deprecated)
+
+Setting only `tenant-id` registers the device as pending in the namespace, to
+be accepted from the device list in the console. Prefer an install key or
+pairing.
+
+```
+$ sudo snap set shellhub tenant-id=<tenant-id>
+```
 
 ## Configuration
 
@@ -57,6 +113,7 @@ This will display the current configuration settings for the ShellHub agent:
 | `private-key`        | `/etc/shellhub.key`         |
 | `server-address`     | `https://cloud.shellhub.io` |
 | `tenant-id`          |                             |
+| `install-key`        |                             |
 | `preferred-hostname` |                             |
 
 ### Setting Configuration
@@ -70,9 +127,16 @@ $ sudo snap set shellhub <key>=<value>
 
 Replace `<key>` and `<value>` with the configuration settings you wish to change.
 
+* `server-address`: The address of the ShellHub server the agent connects to.
+* `install-key`: The install key used to enroll the device (requires `tenant-id`).
+* `tenant-id`: The tenant ID of the ShellHub namespace.
 * `private-key`: The path to the private key used by the ShellHub agent.
-* `server-address`: The address of the ShellHub server the agent will connect to.
-* `tenant-id`: The tenant ID (if applicable) associated with the ShellHub namespace.
+* `preferred-hostname`: The hostname reported to the server instead of the system hostname.
+* `preferred-identity`: The identity (MAC address) reported to the server when the system has none.
+* `keepalive-interval`: The keepalive interval in seconds (agent default: 30).
+
+`preferred-hostname`, `preferred-identity` and `keepalive-interval` take effect
+after `sudo snap restart shellhub`.
 
 ## Building
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,1 +1,30 @@
-#!/bin/sh
+#!/bin/sh -e
+
+# The agent reads its enrollment settings only at startup, so a `snap set` has
+# to restart the service to take effect. snapd does not pass hooks the previous
+# values, so the last applied set is kept in SNAP_DATA to tell a real change
+# apart from a `snap set` of an unrelated key.
+applied="$SNAP_DATA/enrollment.applied"
+
+current=$(printf '%s\n' \
+    "server-address=$(snapctl get server-address)" \
+    "tenant-id=$(snapctl get tenant-id)" \
+    "install-key=$(snapctl get install-key)" \
+    "private-key=$(snapctl get private-key)")
+
+if [ -f "$applied" ]; then
+    previous=$(cat "$applied")
+else
+    # First run, during installation: the service has not started yet.
+    previous="$current"
+fi
+
+if [ "$current" != "$previous" ]; then
+    snapctl restart "$SNAP_INSTANCE_NAME.shellhub"
+fi
+
+# Recorded only after a successful restart: a failed hook makes snapd roll the
+# configuration back, and a state file written ahead of it would make the next
+# `snap set` of the same values skip the restart.
+umask 077
+printf '%s\n' "$current" > "$applied"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,5 +2,6 @@
 
 snapctl set server-address=https://cloud.shellhub.io
 snapctl set tenant-id=
+snapctl set install-key=
 snapctl set private-key=/etc/shellhub.key
 snapctl set preferred-hostname=

--- a/snap/local/bin/shellhub.wrapper
+++ b/snap/local/bin/shellhub.wrapper
@@ -1,16 +1,21 @@
 #!/bin/sh -e
 
-export SERVER_ADDRESS=$(snapctl get server-address)
-export TENANT_ID=$(snapctl get tenant-id)
-export PRIVATE_KEY=$(snapctl get private-key)
-export PREFERRED_HOSTNAME=$(snapctl get preferred-hostname)
-export PREFERRED_IDENTITY=$(snapctl get preferred-identity)
+# Optional settings are exported only when set so the agent applies its own
+# defaults and does not see an empty tenant or install key as configured.
+export_if_set() {
+    value=$(snapctl get "$2")
+    if [ -n "$value" ]; then
+        export "$1=$value"
+    fi
+}
 
-# Only export KEEPALIVE_INTERVAL if it's configured (non-empty)
-# This allows the agent to use its default value when not set
-KEEPALIVE_INTERVAL_VALUE=$(snapctl get keepalive-interval)
-if [ -n "$KEEPALIVE_INTERVAL_VALUE" ]; then
-    export KEEPALIVE_INTERVAL=$KEEPALIVE_INTERVAL_VALUE
-fi
+export SERVER_ADDRESS="$(snapctl get server-address)"
+export PRIVATE_KEY="$(snapctl get private-key)"
 
-exec $SNAP/bin/shellhub "$@"
+export_if_set TENANT_ID tenant-id
+export_if_set INSTALL_KEY install-key
+export_if_set PREFERRED_HOSTNAME preferred-hostname
+export_if_set PREFERRED_IDENTITY preferred-identity
+export_if_set KEEPALIVE_INTERVAL keepalive-interval
+
+exec "$SNAP/bin/shellhub" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,14 +1,10 @@
 name: shellhub
-summary: Centralized SSH for the edge and cloud computing
+summary: Access infrastructure for connected devices
 description: |
-  ShellHub is a centralized SSH gateway that allows users to remotely access and
-  manage their servers and devices from anywhere.
-  One of the main benefits of ShellHub is that it acts as a central gateway for
-  all your Linux servers and devices, allowing you to access them from anywhere
-  with an internet connection. This means you don't have to worry about getting
-  its public IP address, configuring the router, changing VPN/firewall settings
-  or using a jump host to access your servers and devices. This can be
-  inconvenient and time-consuming.
+  The ShellHub agent connects the device outbound to a ShellHub server, so the
+  device can be reached from anywhere without a public address. Enroll it with
+  an install key, by pairing it from the console, or with a tenant ID, and
+  access it through the server from the console or any SSH client.
 adopt-info: shellhub
 grade: stable
 base: core22


### PR DESCRIPTION
The agent enrolls with an install key (`INSTALL_KEY` alongside `TENANT_ID`) or,
with no tenant, by pairing from the console. The snap only wired `TENANT_ID`.

- Add the `install-key` setting and export the optional settings only when set,
  so an empty `tenant-id` leaves the agent in pairing mode instead of looking
  configured.
- Restart the service from the configure hook when `server-address`,
  `tenant-id`, `install-key` or `private-key` change, since the agent reads
  them at startup. The last applied set is kept in `SNAP_DATA` and recorded
  only after the restart succeeds, so a failed hook does not make the next
  `snap set` of the same values skip the restart.
- Document the three enrollment paths, `tenant-id` alone deprecated, and reword
  the store summary and description.

Install keys and pairing need agent v0.27.0, still unreleased; `source-tag`
stays at v0.25.1 and the settings take effect on the next bump.

Tested by packing the configure hook into a throwaway snap: install registers
the settings without restarting, a change to an enrollment key restarts the
service, an unrelated key does not, and with a failing `snapctl restart` snapd
rolls the configuration back and the recorded state stays in sync with it.
